### PR TITLE
Added references for state and process tomography

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Here we collect repositories that demonstrate works on AI in quantum technology.
 - [**Generalizable control for quantum parameter estimation through reinforcement learning**](https://github.com/MilCOS/Quantum_Parameter_Estimation_with_RL) by Xu, Li, Liu, Wang, Yuan, Wang  ([paper](https://www.nature.com/articles/s41534-019-0198-z))
 #### Device calibration
 - [**Efficiently measuring a quantum device using machine learning**](https://github.com/returnddd/CVAE_for_QE) by Lennon, Moon, Camenzind, Yu, Zumbühl, Briggs, Osborne, Laird, Ares ([paper](https://www.nature.com/articles/s41534-019-0193-4))
-
+#### Quantum state and process tomography
+- [**Quantum state tomography with conditional genreative adversarial networks**](https://github.com/quantshah/gd-qpt) by Shahnawaz Ahmed, Carlos Sánchez Muñoz, Franco Nori, and Anton Frisk Kockum ([paper](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.127.140502)) | ([code](https://github.com/quantshah/qst-cgan))
+- [**Gradient-descent quantum process tomography by learning Kraus operators**](https://github.com/quantshah/gd-qpt) by Shahnawaz Ahmed, Fernando Quijandría, Anton Frisk Kockum ([paper](https://arxiv.org/abs/2208.00812)) | ([code](https://github.com/quantshah/gd-qpt))
 #### Quantum Hamiltonian Learning
 - [**Learning models of quantum systems from experiments**](https://github.com/flynnbr11/QMLA) by Gentile, Flynn, Knauer, Wiebe, Paesani, Granade, Rarity, Santagati, Laing ([paper](https://www.nature.com/articles/s41567-021-01201-7))
 

--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ Here we collect repositories that demonstrate works on AI in quantum technology.
 #### Interpreting Measurements
 
 - [**Unsupervised Phase Discovery with Deep Anomaly Detection**](https://github.com/Qottmann/phase-discovery-anomaly-detection) by Kottmann, Huembeli, Lewenstein, Acín ([paper](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.125.170603))
-
 #### Approximating Quantum Dynamics
 - [**Learning quantum dynamics with latent neural ordinary differential equations**](https://github.com/aspuru-guzik-group/QNODE) by Choi, Flam-Spepherd, Kyaw, Aspuru-Guzik ([paper](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.105.042403))
+#### Quantum state and process tomography
+- [**Quantum state tomography with conditional genreative adversarial networks**](https://github.com/quantshah/qst-cgan) by Ahmed, Muñoz, Nori, Frisk Kockum ([paper](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.127.140502))
+- [**Gradient-descent quantum process tomography by learning Kraus operators**](https://github.com/quantshah/gd-qpt) by Ahmed, Quijandría, Frisk Kockum ([paper](https://arxiv.org/abs/2208.00812))
 
 ### 2) Parameter estimation: learning the properties of a quantum system
 #### Quantum Metrology
 - [**Generalizable control for quantum parameter estimation through reinforcement learning**](https://github.com/MilCOS/Quantum_Parameter_Estimation_with_RL) by Xu, Li, Liu, Wang, Yuan, Wang  ([paper](https://www.nature.com/articles/s41534-019-0198-z))
 #### Device calibration
 - [**Efficiently measuring a quantum device using machine learning**](https://github.com/returnddd/CVAE_for_QE) by Lennon, Moon, Camenzind, Yu, Zumbühl, Briggs, Osborne, Laird, Ares ([paper](https://www.nature.com/articles/s41534-019-0193-4))
-#### Quantum state and process tomography
-- [**Quantum state tomography with conditional genreative adversarial networks**](https://github.com/quantshah/qst-cgan) by Shahnawaz Ahmed, Carlos Sánchez Muñoz, Franco Nori, and Anton Frisk Kockum ([paper](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.127.140502)) | ([code](https://github.com/quantshah/qst-cgan))
-- [**Gradient-descent quantum process tomography by learning Kraus operators**](https://github.com/quantshah/gd-qpt) by Shahnawaz Ahmed, Fernando Quijandría, Anton Frisk Kockum ([paper](https://arxiv.org/abs/2208.00812)) | ([code](https://github.com/quantshah/gd-qpt))
+
 #### Quantum Hamiltonian Learning
 - [**Learning models of quantum systems from experiments**](https://github.com/flynnbr11/QMLA) by Gentile, Flynn, Knauer, Wiebe, Paesani, Granade, Rarity, Santagati, Laing ([paper](https://www.nature.com/articles/s41567-021-01201-7))
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here we collect repositories that demonstrate works on AI in quantum technology.
 #### Device calibration
 - [**Efficiently measuring a quantum device using machine learning**](https://github.com/returnddd/CVAE_for_QE) by Lennon, Moon, Camenzind, Yu, Zumbühl, Briggs, Osborne, Laird, Ares ([paper](https://www.nature.com/articles/s41534-019-0193-4))
 #### Quantum state and process tomography
-- [**Quantum state tomography with conditional genreative adversarial networks**](https://github.com/quantshah/gd-qpt) by Shahnawaz Ahmed, Carlos Sánchez Muñoz, Franco Nori, and Anton Frisk Kockum ([paper](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.127.140502)) | ([code](https://github.com/quantshah/qst-cgan))
+- [**Quantum state tomography with conditional genreative adversarial networks**](https://github.com/quantshah/qst-cgan) by Shahnawaz Ahmed, Carlos Sánchez Muñoz, Franco Nori, and Anton Frisk Kockum ([paper](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.127.140502)) | ([code](https://github.com/quantshah/qst-cgan))
 - [**Gradient-descent quantum process tomography by learning Kraus operators**](https://github.com/quantshah/gd-qpt) by Shahnawaz Ahmed, Fernando Quijandría, Anton Frisk Kockum ([paper](https://arxiv.org/abs/2208.00812)) | ([code](https://github.com/quantshah/gd-qpt))
 #### Quantum Hamiltonian Learning
 - [**Learning models of quantum systems from experiments**](https://github.com/flynnbr11/QMLA) by Gentile, Flynn, Knauer, Wiebe, Paesani, Granade, Rarity, Santagati, Laing ([paper](https://www.nature.com/articles/s41567-021-01201-7))


### PR DESCRIPTION
Hi, awesome repo to collect interesting papers on the applications of ML to quantum. I am shamelessly adding two of my own work and a new category of quantum state and process tomography :-).

We have a new paper that explores how quantum processes can be constructed simply with gradient-descent on a manifold without any fancy neural-networks (we still explore them in the supplementary). I hope that is also an example of ML for quantum even though we are not using neural networks and going for a more physics-based ansatz (Kraus operators). 

There are also many possible papers on neural-network QST using restricted Boltzmann machines that I will add to the list. 